### PR TITLE
Save avatar to disk instead of as bytes in XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/avatar-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <!--    <jenkins.version>${jenkins.baseline}.1</jenkins.version>-->
+    <jenkins.version>2.495</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <gitHubRepo>jenkinsci/avatar-plugin</gitHubRepo>
   </properties>

--- a/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
+++ b/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
@@ -10,7 +10,6 @@ import hudson.model.UserPropertyDescriptor;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
+++ b/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
@@ -8,7 +8,12 @@ import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -18,7 +23,6 @@ import javax.imageio.stream.ImageInputStream;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload2.core.FileItem;
-import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
@@ -26,9 +30,7 @@ import org.kohsuke.stapler.export.Exported;
 public class AvatarProperty extends UserProperty implements Action {
     public static final int MAX_AVATAR_IMAGE_SIZE = 10 * 1024 * 1024;
 
-    private static final Logger log = Logger.getLogger(AvatarProperty.class.getName());
-
-    private transient AvatarImage replacementImage;
+    private static final Logger LOGGER = Logger.getLogger(AvatarProperty.class.getName());
 
     private AvatarImage avatarImage;
 
@@ -46,7 +48,7 @@ public class AvatarProperty extends UserProperty implements Action {
     }
 
     public boolean isHasAvatar() {
-        return avatarImage != null;
+        return avatarImage != null && avatarImage.isValid();
     }
 
     /**
@@ -54,15 +56,22 @@ public class AvatarProperty extends UserProperty implements Action {
      */
     public void doImage(StaplerRequest2 req, StaplerResponse2 rsp) {
         if (avatarImage == null) {
-            log.log(Level.WARNING, "No image set for user '" + user.getId() + "'");
+            LOGGER.log(Level.WARNING, "No image set for user '" + user.getId() + "'");
             return;
         }
 
-        rsp.setContentType(avatarImage.mimeType);
-        try {
-            IOUtils.write(avatarImage.imageBytes, rsp.getOutputStream());
+        File file = new File(user.getUserFolder(), "avatar." + avatarImage.filenameSuffix);
+        if (!file.exists()) {
+            LOGGER.log(Level.WARNING, "Avatar image for user '" + user.getId() + "' does not exist");
+            return;
+        }
+
+        try (FileInputStream fileInputStream = new FileInputStream(file); ) {
+            rsp.setContentType(avatarImage.mimeType);
+            rsp.serveFile(
+                    req, fileInputStream, file.lastModified(), file.length(), "avatar." + avatarImage.filenameSuffix);
         } catch (Exception e) {
-            log.log(Level.SEVERE, "Unable to write image for user '" + user.getId() + "'", e);
+            LOGGER.log(Level.SEVERE, "Unable to write image for user '" + user.getId() + "'", e);
         }
     }
 
@@ -70,6 +79,7 @@ public class AvatarProperty extends UserProperty implements Action {
     public UserProperty reconfigure(StaplerRequest2 req, JSONObject form) {
         req.bindJSON(this, form);
 
+        AvatarImage replacementImage;
         try {
             FileItem<?> file = req.getFileItem2("avatar");
 
@@ -77,29 +87,34 @@ public class AvatarProperty extends UserProperty implements Action {
                 if (file.getSize() > MAX_AVATAR_IMAGE_SIZE) {
                     throw new Failure("Uploaded image is too large.");
                 } else {
-                    replacementImage = AvatarImage.fromBytes(file.get());
+                    byte[] bytes = file.get();
+                    replacementImage = AvatarImage.fromBytes(bytes);
 
                     if (replacementImage == null) {
                         throw new Failure("Unsupported image format " + file.getName());
                     }
+
+                    if (replacementImage.isValid()) {
+                        File fileToSave = new File(user.getUserFolder(), "avatar." + replacementImage.filenameSuffix);
+                        try (FileOutputStream fos = new FileOutputStream(fileToSave)) {
+                            fos.write(bytes);
+                        }
+                        avatarImage = replacementImage;
+                    } else {
+                        avatarImage = null;
+                    }
                 }
             } else {
                 if (!req.getParameter("existingAvatar").equals("present")) {
-                    replacementImage = new AvatarImage();
+                    if (avatarImage != null && avatarImage.filenameSuffix != null) {
+                        File fileToDelete = new File(user.getUserFolder(), "avatar." + avatarImage.filenameSuffix);
+                        Files.deleteIfExists(fileToDelete.toPath());
+                    }
+                    avatarImage = null;
                 }
             }
         } catch (jakarta.servlet.ServletException | IOException e) {
             throw new RuntimeException(e);
-        }
-
-        if (replacementImage != null) {
-            if (replacementImage.isValid()) {
-                avatarImage = replacementImage;
-            } else {
-                avatarImage = null;
-            }
-
-            replacementImage = null;
         }
 
         return this;
@@ -133,7 +148,6 @@ public class AvatarProperty extends UserProperty implements Action {
     }
 
     public static class AvatarImage {
-        private byte[] imageBytes;
         private String mimeType;
         private String filenameSuffix;
 
@@ -147,11 +161,10 @@ public class AvatarProperty extends UserProperty implements Action {
 
                 if (mimeTypes.length > 0 && fileSuffixes.length > 0) {
                     AvatarImage avatarImage = new AvatarImage();
-                    avatarImage.imageBytes = bytes;
                     avatarImage.mimeType = mimeTypes[0];
                     avatarImage.filenameSuffix = fileSuffixes[0];
 
-                    log.log(
+                    LOGGER.log(
                             Level.FINE,
                             "Avatar image interpreted as " + avatarImage.mimeType + " ." + avatarImage.filenameSuffix);
 
@@ -163,7 +176,7 @@ public class AvatarProperty extends UserProperty implements Action {
         }
 
         public boolean isValid() {
-            return imageBytes != null;
+            return filenameSuffix != null;
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I don't know why this was being saved as XML before, it meant that users avatars were wasting memory and bloating the user XML for no good reason.

(Potentially it was because you couldn't get the user folder through an API till 2.129).

I haven't done a migration as this plugin has been broken for ~10 years and I would be very surprised if anyone except for myself and @janfaracik have a saved avatar.

We now benefit from browser caching as well

### Testing done

- Uploaded new avatar, see that it writes it to the user folder.
- Click the delete avatar button, see that it deletes the avatar on disk
- Verified that browser caching works
- Ensured that modified avatars show the latest version and not a cached version


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
