### PR TITLE
Add databound constructor

### DIFF
--- a/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
+++ b/src/main/java/net/hurstfrost/jenkins/avatar/user/AvatarProperty.java
@@ -22,6 +22,7 @@ import javax.imageio.stream.ImageInputStream;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload2.core.FileItem;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
@@ -32,6 +33,9 @@ public class AvatarProperty extends UserProperty implements Action {
     private static final Logger LOGGER = Logger.getLogger(AvatarProperty.class.getName());
 
     private AvatarImage avatarImage;
+
+    @DataBoundConstructor
+    public AvatarProperty() {}
 
     @Exported
     public String getAvatarUrl() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

When running from a clean Jenkins instance e.g. `docker run -p 8080:8080 jenkins/jenkins:2.497` it was failing to save the avatar. Not sure why we can't reproduce in `mvn hpi:run`

### Testing done

Built and tested in docker

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
